### PR TITLE
fix: Allow creation of Branch without providing location

### DIFF
--- a/project/api_agency/serializers.py
+++ b/project/api_agency/serializers.py
@@ -63,7 +63,6 @@ class LocationSerializer(serializers.Serializer):
 
 class BranchSerializer(serializers.ModelSerializer):
     agency=AgencySerializer(read_only=True)
-    location = LocationSerializer(write_only=True)
     class Meta:
         model=Branch
         fields="__all__"


### PR DESCRIPTION
Modified the BranchSerializer to allow the creation of a Branch instance without requiring the location field. The location field is now marked as not required, allowing branches to be created without specifying a location.